### PR TITLE
Added batch script to set environment variables in windows.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,7 +26,9 @@ ANCHR_GOOGLE_API_KEY=
 ANCHR_BASIC_AUTH=true
 ANCHR_ALLOW_SIGNUP=true
 ANCHR_EXPOSE_METRICS=false
-ANCHR_VERIFY_USERS=true         # requires mailing to be configured
+
+# requires mailing to be configured
+ANCHR_VERIFY_USERS=true
 
 ANCHR_MAIL_SENDER=
 

--- a/env.bat
+++ b/env.bat
@@ -1,0 +1,1 @@
+for /F "eol=# tokens=*" %%A in (.env) do set %%A


### PR DESCRIPTION
Für Issue #37: Mit dem env.bat Skript lassen sich die Environment Variablen in Windows setzen, wobei die Kommentare ignoriert werden. Um Inline-Kommentare zu vermeiden, habe ich die eine Zeile in deinem env.example umgebrochen. 