### PR TITLE
Fix docker-compose problem with mongodb

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       - mongo
 
   mongo:
-    image: mongo:3.4
+    image: mongo:6.0
     volumes:
       - anchr_db_data:/data/db
       - ./scripts/mongo-init.sh:/docker-entrypoint-initdb.d/mongo-init.sh:ro

--- a/scripts/mongo-init.sh
+++ b/scripts/mongo-init.sh
@@ -1,1 +1,3 @@
-mongo --eval "db.auth('$MONGO_INITDB_ROOT_USERNAME', '$MONGO_INITDB_ROOT_PASSWORD'); db = db.getSiblingDB('$MONGO_INITDB_DATABASE'); db.createUser({ user: '$DB_USER', pwd: '$DB_PASSWORD', roles: [{ role: 'readWrite', db: '$MONGO_INITDB_DATABASE' }] });"
+mongosh -u "$MONGO_INITDB_ROOT_USERNAME" -p "$MONGO_INITDB_ROOT_PASSWORD" --eval "
+use \"$MONGO_INITDB_DATABASE\";
+db.createUser({user: \"$DB_USER\", pwd: \"$DB_PASSWORD\", roles: [{ role: \"dbOwner\", db: \"$MONGO_INITDB_DATABASE\" }]});"


### PR DESCRIPTION
When we use mongo:3.4 we got this error:

```
unable to connect to database at mongodb://anchr:123@mongo:27017/anchr
Error: unable to connect to database at mongodb://anchr:123@mongo:27017/anchr  
   at NativeConnection.onConnectFailed (/app/app.js:10:15)    
 at NativeConnection.emit (node:events:517:28)   
  at /app/node_modules/mongoose/lib/connection.js:764:30  
   at process.processTicksAndRejections (node:internal/process/task_queues:77:11)
```
It's because the mongoose module is updated and no longer support mongo:3.4. As the mention in README file, we have to use mongo:6.x. That's why i change it to 6.0 and change the mongo script to use mongosh instead of mongo and all of  problems fixed.